### PR TITLE
Fix VCS compilations

### DIFF
--- a/wake/demo.wake
+++ b/wake/demo.wake
@@ -34,7 +34,7 @@ def loopbackHook =
 
 def pioHook =
   def name = "pio"
-  def addSources = source "{blockPIOSifiveRoot}/rtl/loopback/pio.v", _
+  def addSources = source "{blockPIOSifiveRoot}/rtl/pio/pio.v", _
   makeBlackBoxHook name (editDUTSimCompileOptionsSourceFiles addSources)
 
 global def demo =

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,7 +5,7 @@
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },
     {
-        "commit": "53b674ecf37394b165cf1fd530bfa90eb27bb763",
+        "commit": "9064afef01f360682b35b869f836bdb48fd4ed8e",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     }


### PR DESCRIPTION
There were two things preventing VCS or any non-Verilator simulator from working:

1. api-generator-sifive was pointed at a revision that didn't include the actual VCS wake code implementations
2. There was an incorrect file path for `pio.v` in `demo.wake`

While this fixes the issue of being able to run VCS or Xcelium, which I did verify on this branch, there are a couple other underlying issues that are worth fixing:

1. The invalid file path for `pio.v` is being inconsistently handled between the VCS and Xcelium code paths, where VCS will panic with an error message of "VCS compile failed!" while Xcelium will actually print out an error message due to passing a `BadPath` to the Job.
2. Even though there was a bad path for `pio.v`, the Verilator run somehow was still working. It's not clear to me why this is the case.