### PR TITLE
update scala to add OMRegisterMap

### DIFF
--- a/craft/loopback/src/loopback-base.scala
+++ b/craft/loopback/src/loopback-base.scala
@@ -112,35 +112,28 @@ object NloopbackTopParams {
 
 class NloopbackTopLogicalTreeNode(component: NloopbackTopBase) extends LogicalTreeNode(() => Some(component.imp.device)) {
   override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(
-      resourceBindings, (resources) => {
-        val name = component.imp.device.describe(resourceBindings).name
-        val omDevice = new scala.collection.mutable.LinkedHashMap[String, Any] with OMDevice {
-          val memoryRegions: Seq[OMMemoryRegion] =
-            DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
+    val name = component.imp.device.describe(resourceBindings).name
+    val omDevice = new scala.collection.mutable.LinkedHashMap[String, Any] with OMDevice {
+      val memoryRegions = component.getOMMemoryRegions(resourceBindings)
+      val interrupts = component.getOMInterrupts(resourceBindings)
+      val _types: Seq[String] = Seq("OMloopback", "OMDevice", "OMComponent", "OMCompoundType")
+    }
+    val userOM = component.userOM
+    val values = userOM.productIterator
+    if (values.nonEmpty) {
+      val pairs = (userOM.getClass.getDeclaredFields.map { field =>
+        assert(field.getName != "memoryRegions", "user Object Model must not define \"memoryRegions\"")
+        assert(field.getName != "interrupts", "user Object Model must not define \"interrupts\"")
+        assert(field.getName != "_types", "user Object Model must not define \"_types\"")
 
-          val interrupts: Seq[OMInterrupt] =
-            DiplomaticObjectModelAddressing.describeGlobalInterrupts(name, resourceBindings)
-
-          val _types: Seq[String] = Seq("OMloopback", "OMDevice", "OMComponent", "OMCompoundType")
-        }
-        val userOM = component.userOM
-        val values = userOM.productIterator
-        if (values.nonEmpty) {
-          val pairs = (userOM.getClass.getDeclaredFields.map { field =>
-            assert(field.getName != "memoryRegions", "user Object Model must not define \"memoryRegions\"")
-            assert(field.getName != "interrupts", "user Object Model must not define \"interrupts\"")
-            assert(field.getName != "_types", "user Object Model must not define \"_types\"")
-
-            field.getName -> values.next
-          }).toSeq
-          omDevice ++= pairs
-        }
-        omDevice("memoryRegions") = omDevice.memoryRegions
-        omDevice("interrupts") = omDevice.interrupts
-        omDevice("_types") = omDevice._types
-        Seq(omDevice)
-      })
+        field.getName -> values.next
+      }).toSeq
+      omDevice ++= pairs
+    }
+    omDevice("memoryRegions") = omDevice.memoryRegions
+    omDevice("interrupts") = omDevice.interrupts
+    omDevice("_types") = omDevice._types
+    Seq(omDevice)
   }
 }
 
@@ -153,6 +146,19 @@ class NloopbackTopBase(val c: NloopbackTopParams)(implicit p: Parameters)
   ResourceBinding { Resource(imp.device, "exists").bind(ResourceString("yes")) }
 
   def userOM: Product with Serializable = Nil
+
+  def omRegisterMaps = Seq(
+)
+
+  def getOMMemoryRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
+    val name = imp.device.describe(resourceBindings).name
+    DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
+  }
+
+  def getOMInterrupts(resourceBindings: ResourceBindings): Seq[OMInterrupt] = {
+    val name = imp.device.describe(resourceBindings).name
+    DiplomaticObjectModelAddressing.describeGlobalInterrupts(name, resourceBindings)
+  }
 
   def logicalTreeNode: LogicalTreeNode = new NloopbackTopLogicalTreeNode(this)
 

--- a/craft/pio/src/pio.scala
+++ b/craft/pio/src/pio.scala
@@ -52,6 +52,13 @@ class NpioTop(c: NpioTopParams)(implicit p: Parameters) extends NpioTopBase(c)(p
   val ioBridgeSink = BundleBridgeSink[pioBlackBoxIO]()
   ioBridgeSink := imp.ioBridgeSource
 
+  // associate register maps with memory regions in Object model
+  override def getOMMemoryRegions(resourceBindings: ResourceBindings) = {
+    super.getOMMemoryRegions(resourceBindings).zip(omRegisterMaps).map { case (memRegion, regmap) =>
+      memRegion.copy(registerMap = Some(regmap))
+    }
+  }
+
   // create a new ports for odata, oenable, and idata
   val ioBridgeSource = BundleBridgeSource(() => new NpioTopIO(c.blackbox.pioWidth))
 

--- a/pio.json5
+++ b/pio.json5
@@ -103,17 +103,17 @@
           name: 'ODATA',
           addressOffset: 0, size: 32,
           displayName: 'Output Data Register',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 32}]
+          fields: [{name: 'data', bits: 32}]
         }, {
           name: 'OENABLE', addressOffset: 32, size: 32,
           displayName: 'Data direction',
           description: 'determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 32}]
+          fields: [{name: 'data', bits: 32}]
         }, {
           name: 'IDATA', addressOffset: 64, size: 32,
           displayName: 'Input data',
           description: 'read the port pins',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 32}]
+          fields: [{name: 'data', bits: 32}]
         }]
       }]
     }


### PR DESCRIPTION
regenerate scala with latest version of `duh-scala` and add code to generate `OMRegisterMap`s in user scala. Also update `pio.json5` to match older DUH register schema, because that is what `duh-scala` is currently using.