### PR TITLE
bump soc-testsocket-sifive for makeOMBlockTest

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "d3f9e19be59f82546746bf797efc7b0d550e4c9a",
+        "commit": "ce97983d26f1ec15494ab573bf067b6e2e7dcb0b",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },


### PR DESCRIPTION
switch from `makeBlockTest` to `makeOMBlockTest` once we have a test that works for both parameterizations of the PIO block.