### PR TITLE
Set access and resetValue attributes for registers.

### DIFF
--- a/craft/pio/src/pio-base.scala
+++ b/craft/pio/src/pio-base.scala
@@ -327,11 +327,11 @@ class NpioTopBase(val c: NpioTopParams)(implicit p: Parameters)
   def omRegisterMaps = Seq(
     OMRegister.convert(
       0 -> RegFieldGroup("ODATA", Some("This drives the output data pins."), padFields(
-        0 -> RegField(pioWidth, Bool(), RegFieldDesc("data", "")))),
+        0 -> RegField(pioWidth, Bool(), RegFieldDesc("data", "", reset = Some(0))))),
       4 -> RegFieldGroup("OENABLE", Some("This determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input."), padFields(
-        0 -> RegField(pioWidth, Bool(), RegFieldDesc("data", "")))),
+        0 -> RegField(pioWidth, Bool(), RegFieldDesc("data", "", reset = Some(0))))),
       8 -> RegFieldGroup("IDATA", Some("This is driven by the input data pins."), padFields(
-        0 -> RegField(pioWidth, Bool(), RegFieldDesc("data", ""))))))
+        0 -> RegField.r(pioWidth, Bool(), RegFieldDesc("data", ""))))))
 
   def getOMMemoryRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
     val name = imp.device.describe(resourceBindings).name

--- a/pio.json5
+++ b/pio.json5
@@ -103,17 +103,34 @@
           name: 'ODATA', addressOffset: 0, size: 'pioWidth',
           displayName: 'Output Data Register',
           description: 'This drives the output data pins.',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 'pioWidth'}]
+          fields: [{
+            name: 'data',
+            bitOffset: 0,
+            bitWidth: 'pioWidth',
+            access: 'read-write',
+            resetValue: 0
+          }]
         }, {
           name: 'OENABLE', addressOffset: 4, size: 'pioWidth',
           displayName: 'Data Direction',
           description: 'This determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input.',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 'pioWidth'}]
+          fields: [{
+            name: 'data',
+            bitOffset: 0,
+            bitWidth: 'pioWidth',
+            access: 'read-write',
+            resetValue: 0
+          }]
         }, {
           name: 'IDATA', addressOffset: 8, size: 'pioWidth',
           displayName: 'Input Data',
           description: 'This is driven by the input data pins.',
-          fields: [{name: 'data', bitOffset: 0, bitWidth: 'pioWidth'}]
+          fields: [{
+            name: 'data',
+            bitOffset: 0,
+            bitWidth: 'pioWidth',
+            access: 'read-only'
+          }],
         }]
       }]
     }


### PR DESCRIPTION
This PR adds the `access` and `resetValue` attributes in the DUH document for each of the registers. Note that this currently contains a regenerated `pio-base.scala` based on the changes to `duh-scala` in https://github.com/sifive/duh-scala/pull/52.

I came up with these values from reading the Verilog itself. Let me know if I've misinterpreted anything, but I think the main thing to note is that I believe the `IDATA` register is effectively read-only and has no defined reset value. My impression is that writes to the `IDATA` register are ignored.