### PR TITLE
Adds a paragraph about producing documentation for pioDUT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,10 +670,10 @@ Summarizing the onboarding instructions, you will need to create three sections 
 
 You can produce a document at any time, even before writing any of these sections, by giving the command:
 ```
-wake makeOnboardDocument pioDUT
+wake makeOnboardingDocument pioDUT
 ```
 The documents will be placed in the "documentation" directory, next to the RTL and verilog files.
-If any sections are missing, they will be filled in with "placeholder" sections.
+If any sections are missing, they will be filled in with placeholder sections.
 
 
 ## Wrap up

--- a/README.md
+++ b/README.md
@@ -651,6 +651,31 @@ wake 'runBitstream "vc707" pioVC707DUT'
 ```
 The bitstream will be placed at `build/api-generator-sifive/pioVC707DUT/mcs/obj/VC707Shell.bit`
 
+
+## Documenting the Block
+To include the block in Scribble manuals and documents, you'll need to
+provide sections of text about the block - what it is, how it is used,
+and how to connect to it. 
+Once the sections are written, you can produce an "Onboarding" document
+which combines those sections so you can verify the documention is correct.
+
+See the 
+[Test Socket Document](https://github.com/sifive/scribble-testsocket-sifive/blob/master/README.md)
+instructions on how to write documentation for a new block.
+
+Summarizing the onboarding instructions, you will need to create three sections of documentation.
+  - an "Overview" which gives a brief paragraph about the device,
+  - a "Programming" chapter which shows how to configure and use the device, and
+  - a "HardwareInterface" chapter which shows how to interface to the device.
+
+You can produce a document at any time, even before writing any of these sections, by giving the command:
+```
+wake makeOnboardDocument pioDUT
+```
+The documents will be placed in the "documentation" directory, next to the RTL and verilog files.
+If any sections are missing, they will be filled in with "placeholder" sections.
+
+
 ## Wrap up
 Checkout tag `complete` if you would like to see how the repo should look
 like after completing the tutorial.

--- a/README.md
+++ b/README.md
@@ -656,8 +656,8 @@ The bitstream will be placed at `build/api-generator-sifive/pioVC707DUT/mcs/obj/
 To include the block in Scribble manuals and documents, you'll need to
 provide sections of text about the block - what it is, how it is used,
 and how to connect to it. 
-Once the sections are written, you can produce an "Onboarding" document
-which combines those sections so you can verify the documention is correct.
+Once the sections are written, you can produce an test "Onboarding" document
+which combines those sections so you can verify the documentation is correct.
 
 See the 
 [Test Socket Document](https://github.com/sifive/scribble-testsocket-sifive/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -656,17 +656,17 @@ The bitstream will be placed at `build/api-generator-sifive/pioVC707DUT/mcs/obj/
 To include the block in Scribble manuals and documents, you'll need to
 provide sections of text about the block - what it is, how it is used,
 and how to connect to it. 
-Once the sections are written, you can produce an test "Onboarding" document
+Once the sections are written, you can produce a test "Onboarding" document
 which combines those sections so you can verify the documentation is correct.
 
 See the 
-[Test Socket Document](https://github.com/sifive/scribble-testsocket-sifive/blob/master/README.md)
+[Test Socket "Onboarding" Document](https://github.com/sifive/scribble-testsocket-sifive/blob/master/README.md)
 instructions on how to write documentation for a new block.
 
 Summarizing the onboarding instructions, you will need to create three sections of documentation.
-  - an "Overview" which gives a brief paragraph about the device,
-  - a "Programming" chapter which shows how to configure and use the device, and
-  - a "HardwareInterface" chapter which shows how to interface to the device.
+  - an "Overview" which gives a brief paragraph about the block,
+  - a "Programming" chapter which shows how to configure and use the block, and
+  - a "HardwareInterface" chapter which shows how to interface to the block.
 
 You can produce a document at any time, even before writing any of these sections, by giving the command:
 ```


### PR DESCRIPTION
Makes reference to the README at scribble-testsocket-sifive::master, but the README there has not been merged yet. 