### PR TITLE
Rewrite Travis CI job as a bash script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,6 @@ install:
 
 jobs:
   include:
-    - name: "Run with internet"
-      script: |
-        docker run --rm \
-          -v "$WIT_WORKSPACE:/mnt/workspace" \
-          --workdir /mnt/workspace \
-          "$BLOCKCI_DOCKER_IMAGE" \
-          bash -c "wake --init . && wake -v --no-tty runSim pioDUT 2>&1 | (head -n 10000; tail -n 1000) && wake -v --no-tty runSim pio16DUT 2>&1 | (head -n 10000; tail -n 1000)"
-
-    - name: "Run without internet"
-      script: |
-        docker run --rm \
-          --network none \
-          -v "$WIT_WORKSPACE:/mnt/workspace" \
-          --workdir /mnt/workspace \
-          "$BLOCKCI_DOCKER_IMAGE" \
-          bash -c "wake --init . && wake -v --no-tty runSim pioDUT 2>&1 | (head -n 10000; tail -n 1000) && wake -v --no-tty runSim pio16DUT 2>&1 | (head -n 10000; tail -n 1000)"
+    - name: "Run tests"
+      script:
+        - ./.travis/run-tests.sh

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -1,0 +1,56 @@
+#/usr/bin/env bash
+
+set -euvo pipefail
+
+
+## Environment variable checking
+
+if [[ -z "$WIT_WORKSPACE" ]]; then
+  >&2 echo Environment variable WIT_WORKSPACE should be set to the path of the Wit workspace.
+  exit 1
+fi
+
+if [[ -z "$BLOCKCI_DOCKER_IMAGE" ]]; then
+  >&2 echo Environment variable BLOCKCI_DOCKER_IMAGE should be set to the name of the Docker image to run.
+  exit 1
+fi
+
+
+## Function definitions
+
+_base_docker_run() {
+  allow_internet="$1"
+  shift
+
+  if [[ "$allow_internet" == "true" ]]; then
+    network_option="--network none"
+  else
+    network_option=""
+  fi
+
+  docker run --rm \
+    $network_option \
+    -v "$WIT_WORKSPACE:/mnt/workspace" \
+    --workdir /mnt/workspace \
+    "$BLOCKCI_DOCKER_IMAGE" \
+    "$@"
+}
+
+# Run docker run with common options
+docker_run() {
+  _base_docker_run true "$@"
+}
+
+# Run docker run with common options but with internet disabled
+docker_run_no_internet() {
+  _base_docker_run false "$@"
+}
+
+
+## Main script
+
+docker_run_no_internet wake --init .
+
+# Tail output to avoid filling up Travis CI maximum stdout.
+docker_run_no_internet wake -v --no-tty runSim pioDUT 2>&1 | (head -n 10000; tail -n 1000)
+docker_run_no_internet wake -v --no-tty runSim pio16DUT 2>&1 | (head -n 10000; tail -n 1000)

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "ce97983d26f1ec15494ab573bf067b6e2e7dcb0b",
+        "commit": "466b3f183a1a110ca344017aa3bcc1cb46b66984",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },


### PR DESCRIPTION
The way we were piping some of the commands in the bash pipeline inlined in docker run command inlined in the the YAML file was unintentionally silencing failues. This writes out the entire script for running Docker commands as a bash script (with set -o pipefail), which makes it easier to express and easier to avoid accidentally silencing output.

This also consolidates the "no internet" and "with internet" jobs together, since the "no internet" one is stricter.

Note that this PR will fail until we bump soc-testsocket-sifive with the changes made in https://github.com/sifive/soc-testsocket-sifive/pull/4.