### PR TITLE
Bump to latest soc-testsocket-sifive.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ services:
 env:
   global:
     BLOCK_REPO=$TRAVIS_BUILD_DIR
-    BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.2.1
-    WIT_DOCKER_IMAGE=sifive/wit:0.10.1
+    BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.3.0
+    WIT_DOCKER_IMAGE=sifive/wit:v0.11.1
     WIT_WORKSPACE=$HOME/workspace
 
 before_install:
@@ -35,7 +35,7 @@ install:
       -v "$WIT_WORKSPACE:/mnt/workspace" \
       --workdir /mnt/workspace \
       "$WIT_DOCKER_IMAGE" \
-      bash -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.2.1"
+      bash -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0"
 
 jobs:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0]
+
+This represents the first versioned release of block-pio-sifive, and it contains a number of new features compared to previous "unversioned" commits.
+
+### New Features
+
+- Chisel elaboration now also emits an Object Model JSON and a Device Tree file with configuration-specific information about the PIO block.
+- A set of C driver files for interfacing with the PIO block's registers, allowing software that uses the PIO block to be written in a more portable way. These drivers are also combined with a set of header files that contain configuration-specific information such as base address, which are generated automatically based on the design configuration.
+- Wake functions for building a parameterized document that describes both the programming interface and RTL integration information.
+- Continuous integration checks have been added, testing the above workflows on every pull request and commit to the repository.
+- A second configuration of the PIO block with a width of 16 has been added. A second DUT has been created as well, with a Wake variable named `pio16DUT`. This allows for easily testing changes across multiple parameterizations of the PIO block.
+
+### Backwards incompatible changes
+
+- There are new dependencies or Ruby (~2.5) and Python (~3.7), so the running environment must have them installed.
+- The directory structure has been changed for greater consistency between different file types.
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/3ae174ec5bcae93674bc6ab16a9fa8177b41b9d7...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Backwards-Incompatible Changes
+
+- Upgrade to environment-blockci-sifive 0.3.0 and wake 0.17.1. See their
+  respective changelogs for individual backwards-incompatible changes.
+- Upgrade to latest api-generator-sifive and soc-testsocket-sifive. These
+  packages do not yet have stable APIs.
+
 ## [0.1.0]
 
 This represents the first versioned release of block-pio-sifive, and it contains a number of new features compared to previous "unversioned" commits.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The loopback block outputs the xor of oenable and odata to idata.
 #### wake
 
 * wake is a build tool
-* Use version 0.15.2
-* For installation instructions see the [wake README](https://github.com/sifive/wake/tree/v0.15.2#installing-dependencies)
-* [wake tutorial](https://github.com/sifive/wake/blob/v0.15.2/share/doc/wake/tutorial.md)
-* [wake quickref](https://github.com/sifive/wake/blob/v0.15.2/share/doc/wake/quickref.md)
+* Use version 0.17.1
+* For installation instructions see the [wake README](https://github.com/sifive/wake/tree/v0.17.1#installing-dependencies)
+* [wake tutorial](https://github.com/sifive/wake/blob/v0.17.1/share/doc/wake/tutorial.md)
+* [wake quickref](https://github.com/sifive/wake/blob/v0.17.1/share/doc/wake/quickref.md)
 
 #### duh
 

--- a/drivers/metal/sifive_pio.c
+++ b/drivers/metal/sifive_pio.c
@@ -12,7 +12,7 @@ void pio_odata_write(uint8_t *pio_base, uint16_t bit,
                      bool data) {
     volatile uint8_t *control_base = pio_base;
 
-    unsigned int byte_to_write = (bit >> 3) + (METAL_PIO_ODATA);
+    unsigned int byte_to_write = (bit >> 3) + (PIO_REGISTER_ODATA_DATA_BYTE);
 
     uint8_t bit_to_write = 1 << (bit & 0x0007);
 
@@ -27,7 +27,7 @@ void pio_oenable_write(uint8_t *pio_base, uint16_t bit,
                        bool data) {
     volatile uint8_t *control_base = pio_base;
 
-    unsigned int byte_to_write = (bit >> 3) + (METAL_PIO_OENABLE);
+    unsigned int byte_to_write = (bit >> 3) + (PIO_REGISTER_OENABLE_DATA_BYTE);
     uint8_t bit_to_write = 1 << (bit & 0x0007);
     if (data) {
         METAL_PIO_REGB(byte_to_write) |= bit_to_write;
@@ -38,7 +38,7 @@ void pio_oenable_write(uint8_t *pio_base, uint16_t bit,
 
 bool pio_idata_read(uint8_t *pio_base, uint16_t bit) {
     volatile uint8_t *control_base = pio_base;
-    unsigned int byte_to_read = (bit >> 3) + (METAL_PIO_IDATA);
+    unsigned int byte_to_read = (bit >> 3) + (PIO_REGISTER_IDATA_DATA_BYTE);
     uint8_t bit_to_read = 1 << (bit & 0x0007);
     return !!(METAL_PIO_REGB(byte_to_read) & bit_to_read);
 }
@@ -71,7 +71,7 @@ bool metal_pio_idata_read(const struct metal_pio *pio, uint16_t bit) {
  */
 
 struct metal_pio metal_pio = {
-    .pio_width = METAL_PIO_ODATA_WIDTH,
+    .pio_width = PIO_REGISTER_ODATA_DATA_WIDTH,
     .vtable.v_pio_odata_write = pio_odata_write,
     .vtable.v_pio_oenable_write = pio_oenable_write,
     .vtable.v_pio_idata_read = pio_idata_read,

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,11 +1,11 @@
 [
     {
-        "commit": "466b3f183a1a110ca344017aa3bcc1cb46b66984",
+        "commit": "471dfa250b87a16a461f583e2b7eed69293cef02",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },
     {
-        "commit": "43b6fa2fa2722ea5770bafc738fb035409f5b6e5",
+        "commit": "0fbb27b31ffabe6c49850a8ef5075239c32dc50a",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
This points to https://github.com/sifive/soc-testsocket-sifive/pull/8, which just helps us get this repo pointed to a much more recent version of the dependencies.

Once that PR merges in, I'll update this one to point to the merged commit rather than a branch.