### PR TITLE
Fix loopback attach instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,11 +462,10 @@ with the following lines.
     // instantiate and connect the loopback vip in the test harness
     bap.testHarness {
       // instantiate the loopback vip
-      val loopbackP = NloopbackTopParams(
+      val loopback = LazyModule(new NloopbackTop(NloopbackTopParams(
         blackbox = loopbackParams(
           pioWidth = c.blackbox.pioWidth,
-          cacheBlockBytes = p(CacheBlockBytes)))
-      val loopback = NloopbackTop.attach(loopbackP)(bap)
+          cacheBlockBytes = p(CacheBlockBytes)))))
 
       // route loopback signals to the testharness
       val loopbackNode = BundleBridgeSink[loopbackBlackBoxIO]()

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,11 +1,11 @@
 [
     {
-        "commit": "466b3f183a1a110ca344017aa3bcc1cb46b66984",
+        "commit": "471dfa250b87a16a461f583e2b7eed69293cef02",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },
     {
-        "commit": "43b6fa2fa2722ea5770bafc738fb035409f5b6e5",
+        "commit": "0fbb27b31ffabe6c49850a8ef5075239c32dc50a",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
update the scala instructions so that we do not produce a object model for the loopback vip and so that the resulting scala code matches what is in master. also bump wit dependencies to match master.

should hopefully fix https://github.com/sifive/block-pio-sifive/issues/47