### PR TITLE
Bump wit to 0.12.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     BLOCK_REPO=$TRAVIS_BUILD_DIR
     BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.3.0
-    WIT_DOCKER_IMAGE=sifive/wit:v0.11.1
+    WIT_DOCKER_IMAGE=sifive/wit:v0.12.0
     WIT_WORKSPACE=$HOME/workspace
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The loopback block outputs the xor of oenable and odata to idata.
 #### wit
 
 * Wit is a workspace manager
-* Use version 0.11.0
+* Use version 0.12.0
 * Please see instructions on the [wit README](https://github.com/sifive/wit)
 
 #### wake


### PR DESCRIPTION
This is because all older versions of Wit will fail to fetch Scala dependencies, now that Sonatype has disabled non-TLS access to their Maven repository.