### PR TITLE
Update all dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     BLOCK_REPO=$TRAVIS_BUILD_DIR
     BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.3.0
-    WIT_DOCKER_IMAGE=sifive/wit:v0.12.0
+    WIT_DOCKER_IMAGE=sifive/wit:v0.13.0
     WIT_WORKSPACE=$HOME/workspace
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 env:
   global:
     BLOCK_REPO=$TRAVIS_BUILD_DIR
-    BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.3.0
+    BLOCKCI_DOCKER_IMAGE=sifive/environment-blockci:0.4.0
     WIT_DOCKER_IMAGE=sifive/wit:v0.13.0
     WIT_WORKSPACE=$HOME/workspace
 
@@ -35,7 +35,7 @@ install:
       -v "$WIT_WORKSPACE:/mnt/workspace" \
       --workdir /mnt/workspace \
       "$WIT_DOCKER_IMAGE" \
-      bash -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0"
+      bash -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.4.0"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
       -v "$WIT_WORKSPACE:/mnt/workspace" \
       --workdir /mnt/workspace \
       "$WIT_DOCKER_IMAGE" \
-      bash -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.4.0"
+      sh -c "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && wit init /mnt/workspace -a /mnt/block-pio-sifive -a git@github.com:sifive/environment-blockci-sifive.git::0.4.0"
 
 jobs:
   include:

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -52,7 +52,7 @@ docker_run_no_internet() {
 docker_run_no_internet wake --init .
 # Run preinstall step with internet so that we can install Python and Ruby
 # dependencies
-docker_run wake -v --no-tty preinstall Unit
+docker_run wake --no-tty preinstall Unit
 
 # Tail output to avoid filling up Travis CI maximum stdout.
 docker_run_no_internet wake -v --no-tty runSim pioDUT 2>&1 | (head -n 10000; tail -n 1000)

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The loopback block outputs the xor of oenable and odata to idata.
 #### wake
 
 * wake is a build tool
-* Use version 0.17.1
-* For installation instructions see the [wake README](https://github.com/sifive/wake/tree/v0.17.1#installing-dependencies)
-* [wake tutorial](https://github.com/sifive/wake/blob/v0.17.1/share/doc/wake/tutorial.md)
-* [wake quickref](https://github.com/sifive/wake/blob/v0.17.1/share/doc/wake/quickref.md)
+* Use version 0.17.2
+* For installation instructions see the [wake README](https://github.com/sifive/wake/tree/v0.17.2#installing-dependencies)
+* [wake tutorial](https://github.com/sifive/wake/blob/v0.17.2/share/doc/wake/tutorial.md)
+* [wake quickref](https://github.com/sifive/wake/blob/v0.17.2/share/doc/wake/quickref.md)
 
 #### duh
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The loopback block outputs the xor of oenable and odata to idata.
 #### wit
 
 * Wit is a workspace manager
-* Use version 0.12.0
+* Use version 0.13.0
 * Please see instructions on the [wit README](https://github.com/sifive/wit)
 
 #### wake

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,7 +10,7 @@
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },
     {
-        "commit": "1c38068e5338dce8594f3aef0466c6333f46a24d",
+        "commit": "c51c7980f86afa2d1841c524644fefbe564cd982",
         "name": "api-scala-sifive",
         "source": "git@github.com:sifive/api-scala-sifive.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "471dfa250b87a16a461f583e2b7eed69293cef02",
+        "commit": "eb6cfc6347a2c48d7239d6ee3bdb30ce92d04e57",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "eb6cfc6347a2c48d7239d6ee3bdb30ce92d04e57",
+        "commit": "c5598b8cde470e946c8cc7d1c8fc2fa8f8b1ce5b",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },


### PR DESCRIPTION
This updates:
- `soc-testsocket-sifive`: for benefits of https://github.com/sifive/soc-testsocket-sifive/pull/20
- `api-scala-sifive`: updated to `v0.2.0` to allow use of `wit v0.13.0`
- `api-generator-sifive`: dependency is removed in favor of relying on the one in `soc-testsocket-sifive`'s manifest