### PR TITLE
match 'irq' bus interface to real INTERRUPT busDef

### DIFF
--- a/docs/pio.json5
+++ b/docs/pio.json5
@@ -162,19 +162,13 @@
     }, {
       name: 'irq',
       interfaceMode: 'master',
-      busType: {vendor: 'sifive.com', library: 'free', name: 'interrupts', version: '0.1.0'},
+      busType: {vendor: 'sifive.com', library: 'PRCI', name: 'INTERRUPT', version: '0.1.0'},
       abstractionTypes: [{
         viewRef: 'RTLview',
-        portMaps: [
-          'irq0',
-          'irq1'
-        ]
+        portMaps: {
+          IRQ: ['irq0', 'irq1']
+        }
       }]
-    }],
-    addressSpaces: [{
-      name: 'csrAddressSpace',
-      range: 1024,
-      width: 32
     }],
     memoryMaps: [{$ref: '#/definitions/csrMemMap'}],
     model: {


### PR DESCRIPTION
We have real busDef for interrupt now:
https://github.com/sifive/duh-bus/blob/master/specs/sifive.com/PRCI/INTERRUPT/0.1.0/INTERRUPT_rtl.json5

This PR is to fix PIO block using this interrupt busDef

It will require related changes in `duh-scala` to operate

https://github.com/sifive/duh-scala/pull/81