### PR TITLE
Update after fixes for duh-scala#79

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The loopback block outputs the xor of oenable and odata to idata.
 * duh assists in IP onboarding
 * Please see instructions on [duh README](https://github.com/sifive/duh)
 
+* Note: duh-scala used was 0.16.0 (32df4ab)
 #### Other dependencies
 
 * riscv-gnu-toolchain

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The loopback block outputs the xor of oenable and odata to idata.
 
 #### duh
 
-* `npm i duh@1.13.1`
+* `npm i duh@1.17.10`
 * duh assists in IP onboarding
 * Please see instructions on [duh README](https://github.com/sifive/duh)
 

--- a/craft/pio/src/pio.scala
+++ b/craft/pio/src/pio.scala
@@ -52,12 +52,6 @@ class NpioTop(c: NpioTopParams)(implicit p: Parameters) extends NpioTopBase(c)(p
   val ioBridgeSink = BundleBridgeSink[pioBlackBoxIO]()
   ioBridgeSink := imp.ioBridgeSource
 
-  // associate register maps with memory regions in Object model
-  override def getOMMemoryRegions(resourceBindings: ResourceBindings) = {
-    super.getOMMemoryRegions(resourceBindings).zip(omRegisterMaps).map { case (memRegion, regmap) =>
-      memRegion.copy(registerMap = Some(regmap))
-    }
-  }
 
   // create a new ports for odata, oenable, and idata
   val ioBridgeSource = BundleBridgeSource(() => new NpioTopIO(c.blackbox.pioWidth))

--- a/docs/pio.json5
+++ b/docs/pio.json5
@@ -144,6 +144,7 @@
     busInterfaces: [{
       name: 'ctrl',
       interfaceMode: 'slave',
+      memoryMapRef: 'CSR',
       busType: {vendor: 'amba.com', library: 'AMBA4', name: 'AXI4-Lite', version: 'r0p0_0'},
       abstractionTypes: [{
         viewRef: 'RTLview',

--- a/docs/pio.json5
+++ b/docs/pio.json5
@@ -162,19 +162,13 @@
     }, {
       name: 'irq',
       interfaceMode: 'master',
-      busType: {vendor: 'sifive.com', library: 'free', name: 'interrupts', version: '0.1.0'},
+      busType: {vendor: 'sifive.com', library: 'PRCI', name: 'INTERRUPT', version: '0.1.0'},
       abstractionTypes: [{
         viewRef: 'RTLview',
-        portMaps: [
-          'irq0',
-          'irq1'
-        ]
+        portMaps: {
+          IRQ: ['irq0', 'irq1']
+        }
       }]
-    }],
-    addressSpaces: [{
-      name: 'csrAddressSpace',
-      range: 1024,
-      width: 32
     }],
     memoryMaps: [{$ref: '#/definitions/csrMemMap'}],
     model: {

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "c5598b8cde470e946c8cc7d1c8fc2fa8f8b1ce5b",
+        "commit": "8a3229119f56eeeb4192d3c9aced85b16422abf0",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "8a3229119f56eeeb4192d3c9aced85b16422abf0",
+        "commit": "0645f8dcd6598b0c0def98eee738fb815f12893c",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },


### PR DESCRIPTION
This bumps soc-testsocket-sifive to pull in changes to api-generator-sifive and rocket-chip to demonstrate better handling for multiple memory maps and address blocks for a given device. 

I also re-generated the files in craft/pio/src using duh-scala @ 0.16.0, which does not yet seem to be part of a full duh release. I updated the README to capture this.
