### PR TITLE
Add a dummy, second test program.

### DIFF
--- a/build-rules/wake/demo.wake
+++ b/build-rules/wake/demo.wake
@@ -67,7 +67,7 @@ global def pioVC707DUT =
   def frequency = 50
   makeVC707TestSocketDUT name frequency blocks
 
-publish dutTests = demoPioTest, demoPio16Test, Nil
+publish dutTests = demoPioTest, demoPio16Test, passPioTest, Nil
 
 global def demoPioTest =
   def name = "demo"
@@ -85,6 +85,23 @@ global def demoPio16Test =
   def name = "demo16"
   def block = pio16Block
   def program = demo16
+  def plusargs =
+    NamedArg        "verbose",
+    NamedArgInteger "random_seed"      1234,
+    NamedArgInteger "tilelink_timeout" 16000,
+    NamedArgInteger "max-cycles"       50000,
+    Nil
+  makeBlockTest name block program plusargs
+
+# A dummy second test to make it easier to test workflows that involve multiple tests
+global def passPioTest =
+  def name = "pass"
+  def block = pioBlock
+  def program =
+    def cFiles =
+      source "{blockPIOSifiveRoot}/tests/c/pass/main.c",
+      Nil
+    makeTestProgramPlan name cFiles
   def plusargs =
     NamedArg        "verbose",
     NamedArgInteger "random_seed"      1234,

--- a/tests/c/pass/main.c
+++ b/tests/c/pass/main.c
@@ -1,0 +1,5 @@
+// A dummy test that should always pass by returning 0.
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
cc @RajeshVaradharajan

It's sometimes difficult to test scenarios where having a second test program matters; for example both https://github.com/sifive/api-generator-sifive/pull/67 and https://github.com/sifive/api-generator-sifive/pull/72 would have probably been easier to notice if block-pio-sifive actually had more than one test (per design).

In addition, not having a second test program causes us to miss things that are idiosyncratic of Wake, such as disallowing two Jobs to write to the same file. This shows up in places where having multiple test programs would naively write to the same place, such as recording coverage metrics, and it's better if we can catch these up front when testing against block-pio-sifive rather than against a repo that actually has more than one test.