### PR TITLE
bump rocket-chip to pick up fix for bundle bridge parenthesis

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "22d1391a4f3ebbb12fdc603ed1d8243ebb747a40",
+        "commit": "36d0f0f16b66af16769024c7c957447f1d5b34a9",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "36d0f0f16b66af16769024c7c957447f1d5b34a9",
+        "commit": "b9806ae597c95cc398226e6a16a14b4fd5789d5e",
         "name": "soc-testsocket-sifive",
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },


### PR DESCRIPTION
This bumps soc-testsocket-sifive to pick up fix in rocket-chip for broken backwards compatibility of BundleBridgeSink without parens