### PR TITLE
Bump api-generator-sifive to get bumped freedom software.

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,7 +5,7 @@
         "source": "git@github.com:sifive/soc-testsocket-sifive.git"
     },
     {
-        "commit": "b50492b07cdf07e84de9834f83972f530188b0c9",
+        "commit": "06e5e068ffe7045de51f9a6fcfd40d34547e3859",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
This bumps api-generator-sifive to https://github.com/sifive/api-generator-sifive/pull/102, bumping freedom-metal to get https://github.com/sifive/freedom-metal/pull/355 and ldscript-generator to the tip of master. I had tested this locally, but want to confirm that this passes CI in block-pio-sifive.

cc @rmac-sifive, @mjolarpet, @nategraff-sifive, @bsousi5